### PR TITLE
fix(ci): Fix bash arithmetic in bootstrap workflow

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -74,11 +74,11 @@ jobs:
             # Check if label exists
             if gh label list --json name --jq ".[].name" | grep -q "^${name}$"; then
               echo "⏭️  Label '$name' already exists - skipping"
-              ((SKIPPED_COUNT++))
+              SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
             else
               gh label create "$name" --description "$description" --color "$color"
               echo "✅ Created label: $name"
-              ((CREATED_COUNT++))
+              CREATED_COUNT=$((CREATED_COUNT + 1))
             fi
           }
 


### PR DESCRIPTION
## Summary
Fixes a bash scripting bug in the bootstrap workflow that was preventing label creation from completing.

## Problem
The `((COUNT++))` syntax returns 0 when incrementing from 0, which causes `bash -e` to exit with an error. This prevented the bootstrap workflow from creating all required labels.

## Solution
Changed to `COUNT=$((COUNT + 1))` syntax which is compatible with `bash -e`.

## Testing
- The workflow will be tested automatically after merge
- This allows the bootstrap workflow to run successfully and create all required labels

Closes #2 (if an issue was created for this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)