### PR TITLE
chore: Add beads workflow integration docs and gitignore

### DIFF
--- a/.beads/issues.jsonl
+++ b/.beads/issues.jsonl
@@ -1,0 +1,2 @@
+{"id":"claude-gh-standup-b78","title":"aaa","status":"open","priority":2,"issue_type":"task","created_at":"2026-01-06T16:00:18.26721+02:00","created_by":"garden","updated_at":"2026-01-06T16:00:18.26721+02:00"}
+{"id":"claude-gh-standup-e4l","title":"aaa","status":"open","priority":2,"issue_type":"task","created_at":"2026-01-06T16:28:53.091831+02:00","created_by":"garden","updated_at":"2026-01-06T16:28:53.091831+02:00"}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ Thumbs.db
 # Temp files
 *.tmp
 *.log
+
+# bv (beads viewer) local config and caches
+.bv/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -735,5 +735,69 @@ bd export -o .beads/issues.jsonl
 
 ---
 
+<!-- bv-agent-instructions-v1 -->
+
+---
+
+## Beads Workflow Integration
+
+This project uses [beads_viewer](https://github.com/Dicklesworthstone/beads_viewer) for issue tracking. Issues are stored in `.beads/` and tracked in git.
+
+### Essential Commands
+
+```bash
+# View issues (launches TUI - avoid in automated sessions)
+bv
+
+# CLI commands for agents (use these instead)
+bd ready              # Show issues ready to work (no blockers)
+bd list --status=open # All open issues
+bd show <id>          # Full issue details with dependencies
+bd create --title="..." --type=task --priority=2
+bd update <id> --status=in_progress
+bd close <id> --reason="Completed"
+bd close <id1> <id2>  # Close multiple issues at once
+bd sync               # Commit and push changes
+```
+
+### Workflow Pattern
+
+1. **Start**: Run `bd ready` to find actionable work
+2. **Claim**: Use `bd update <id> --status=in_progress`
+3. **Work**: Implement the task
+4. **Complete**: Use `bd close <id>`
+5. **Sync**: Always run `bd sync` at session end
+
+### Key Concepts
+
+- **Dependencies**: Issues can block other issues. `bd ready` shows only unblocked work.
+- **Priority**: P0=critical, P1=high, P2=medium, P3=low, P4=backlog (use numbers, not words)
+- **Types**: task, bug, feature, epic, question, docs
+- **Blocking**: `bd dep add <issue> <depends-on>` to add dependencies
+
+### Session Protocol
+
+**Before ending any session, run this checklist:**
+
+```bash
+git status              # Check what changed
+git add <files>         # Stage code changes
+bd sync                 # Commit beads changes
+git commit -m "..."     # Commit code
+bd sync                 # Commit any new beads changes
+git push                # Push to remote
+```
+
+### Best Practices
+
+- Check `bd ready` at session start to find available work
+- Update status as you work (in_progress → closed)
+- Create new issues with `bd create` when you discover tasks
+- Use descriptive titles and set appropriate priority/type
+- Always `bd sync` before ending session
+
+<!-- end-bv-agent-instructions -->
+
 **Last Updated**: 2026-01-05
 **Maintained By**: claude-md-guardian agent (auto-sync on major changes)
+


### PR DESCRIPTION
## Summary
- Add `.bv/` to `.gitignore` for beads viewer local config
- Add beads workflow integration section to CLAUDE.md with CLI commands and best practices
- Initialize `.beads/issues.jsonl` with test issues

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)