### PR TITLE
docs: Add Working Style section and cleanup CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Keep this managed block so 'openspec update' can refresh the instructions.
 
 ## Beads Issue Tracking
 
-**BEFORE ANY WORK**: Run `bd ready` to see unblocked tasks.
+**BEFORE ANY WORK**: Run `bd onboard` if you haven't already this session, then `bd ready` to see unblocked tasks.
 
 ### STRICT RULE: Every `bd create` MUST include `-d`
 
@@ -107,6 +107,17 @@ Keep OpenSpec `tasks.md` and Beads in sync:
 - When completing a Beads issue, also mark `[x]` in tasks.md
 - When all Beads issues for a change are closed, run `/openspec:archive`
 
+### Importing OpenSpec Tasks Checklist
+
+When converting OpenSpec tasks to Beads issues, ALWAYS include full context. **REQUIRED in every issue description:**
+
+1. **Spec file reference path** - e.g., `openspec/changes/<name>/spec.md`
+2. **Relevant requirements** - Copy key points from the spec
+3. **Acceptance criteria** - How to verify it's done
+4. **Technical context** - Files to modify, dependencies, gotchas
+
+**The test:** Could someone implement this issue correctly with ONLY the bd description and access to the codebase? If not, add more context.
+
 ### Label Conventions
 
 - `openspec:<change-name>` - Links issue to OpenSpec change proposal
@@ -119,24 +130,70 @@ Keep OpenSpec `tasks.md` and Beads in sync:
 
 **When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
 
-**MANDATORY WORKFLOW:**
+### MANDATORY WORKFLOW
 
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
-2. **Run quality gates** (if code changed) - Tests, linters, builds
-3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - This is MANDATORY:
-   ```bash
-   git pull --rebase
-   bd sync
-   git push
-   git status  # MUST show "up to date with origin"
-   ```
-5. **Clean up** - Clear stashes, prune remote branches
-6. **Verify** - All changes committed AND pushed
-7. **Hand off** - Provide context for next session
+#### 1. File Issues for Remaining Work
+Create Beads issues for anything that needs follow-up:
+```bash
+bd create "TODO: <description>" -t task -p 2 -d "## Context..."
+bd create "Bug: <description>" -t bug -p 1 -d "## Steps to reproduce..."
+```
 
-**CRITICAL RULES:**
+#### 2. Run Quality Gates (if code changed)
+- Run tests, linters, builds
+- File P0 issues if builds are broken
+
+#### 3. Update All Tracking
+**Beads issues:**
+```bash
+bd close <id> --reason "Completed"           # Finished work
+bd update <id> --status in_progress          # Partially done
+bd update <id> --add-note "Session end: <context>"  # Add context
+```
+
+**OpenSpec tasks.md:**
+- Mark completed tasks: `- [x] Task description`
+- Add notes for partial progress
+
+#### 4. Sync and Push (MANDATORY)
+```bash
+# Sync Beads database
+bd sync
+
+# Pull, rebase, push
+git pull --rebase
+git add -A
+git commit -m "chore: session end - <summary>"
+git push
+
+# VERIFY - must show "up to date with origin"
+git status
+```
+
+#### 5. Clean Up
+- Clear stashes: `git stash clear` (if appropriate)
+- Prune remote branches if needed
+
+#### 6. Verify Final State
+```bash
+bd list --status open    # Review open issues
+bd ready                 # Show what's ready for next session
+git status               # Must be clean and pushed
+```
+
+#### 7. Hand Off
+Provide context for next session:
+```
+## Next Session Context
+- Current epic: <id and name>
+- Ready work: `bd ready` shows N issues
+- Blocked items: <any blockers>
+- Notes: <important context>
+```
+
+### CRITICAL RULES
 - Work is NOT complete until `git push` succeeds
 - NEVER stop before pushing - that leaves work stranded locally
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
+- ALWAYS run `bd sync` before committing to capture issue changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,104 @@ Keep this managed block so 'openspec update' can refresh the instructions.
 
 <!-- OPENSPEC:END -->
 
+## Beads Issue Tracking
+
+**BEFORE ANY WORK**: Run `bd ready` to see unblocked tasks.
+
+### STRICT RULE: Every `bd create` MUST include `-d`
+
+Issues must be **self-contained** - an agent must understand the task without re-reading OpenSpec files or external context.
+
+**FORBIDDEN** - will result in incomplete work:
+```bash
+bd create "Update file.ts" -t task
+```
+
+**REQUIRED** - every issue needs full context:
+```bash
+bd create "Add description field to entity" -t task -p 2 \
+  -l "openspec:billing-improvements" \
+  -d "## Spec Reference
+openspec/changes/billing-improvements/spec.md
+
+## Requirements
+- Add 'description: string' field (nullable)
+- Sync field from API on webhook
+
+## Acceptance Criteria
+- Field populated from external API metadata
+
+## Files to modify
+- src/entities/price.entity.ts
+- src/services/webhook.service.ts"
+```
+
+**The test**: Could someone implement this issue correctly with ONLY the bd description and access to the codebase? If not, add more context.
+
+### When to Use Beads vs OpenSpec
+
+| Situation | Tool | Action |
+|-----------|------|--------|
+| New feature/capability | OpenSpec | `/openspec:proposal` first |
+| Approved spec ready for implementation | Both | Import tasks to Beads, then implement |
+| Bug fix, small task, tech debt | Beads | `bd create` directly |
+| Discovered issue during work | Beads | `bd create --discovered-from <parent>` |
+| Tracking what's ready to work on | Beads | `bd ready` |
+| Feature complete | OpenSpec | `/openspec:archive` |
+
+### Daily Workflow
+
+1. **Orient**: Run `bd ready` to see unblocked work
+2. **Pick work**: Select highest priority ready issue OR continue in-progress work
+3. **Update status**: `bd update <id> --status in_progress`
+4. **Implement**: Do the work
+5. **Discover**: File any new issues found: `bd create "Found: <issue>" -t bug --discovered-from <current-id>`
+6. **Complete**: `bd close <id> --reason "Implemented"`
+
+### Converting OpenSpec Tasks to Beads
+
+When an OpenSpec change is approved and ready for implementation:
+
+```bash
+# Create epic for the change
+bd create "<change-name>" -t epic -p 1 -l "openspec:<change-name>" \
+  -d "## OpenSpec Change
+Implements openspec/changes/<change-name>/
+
+## Scope
+<summary of what this change accomplishes>
+
+## Spec Files
+- openspec/changes/<change-name>/spec.md
+- openspec/changes/<change-name>/tasks.md"
+
+# For each task in tasks.md, create a child issue with FULL context
+bd create "<task description>" -t task -l "openspec:<change-name>" \
+  -d "## Spec Reference
+<path to relevant spec section>
+
+## Requirements
+<copy key requirements from spec>
+
+## Acceptance Criteria
+<how to verify it's done>
+
+## Files to modify
+<list specific files>"
+```
+
+Keep OpenSpec `tasks.md` and Beads in sync:
+- When completing a Beads issue, also mark `[x]` in tasks.md
+- When all Beads issues for a change are closed, run `/openspec:archive`
+
+### Label Conventions
+
+- `openspec:<change-name>` - Links issue to OpenSpec change proposal
+- `spec:<spec-name>` - Links to specific spec file
+- `discovered` - Issue found during other work
+- `tech-debt` - Technical debt items
+- `blocked-external` - Blocked by external dependency
+
 ## Landing the Plane (Session Completion)
 
 **When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,31 +162,6 @@ jbang scripts/TeamAggregator.java alice bob charlie 7
 # If not visible, restart Claude Code or check installation path
 ```
 
-### Testing Scripts Individually
-
-Each Java script can be tested independently with JBang:
-
-```bash
-# CollectActivity.java - Fetches GitHub activity
-jbang scripts/CollectActivity.java <username> <days> [repo]
-
-# Example:
-jbang scripts/CollectActivity.java octocat 3
-jbang scripts/CollectActivity.java octocat 7 owner/repo
-
-# AnalyzeDiffs.java - Parses PR diffs for file statistics
-jbang scripts/AnalyzeDiffs.java '<activity-json>'
-
-# GenerateReport.java - Calls Claude AI
-jbang scripts/GenerateReport.java '<activity-json>' '<diff-summary>'
-
-# ExportUtils.java - Format conversion
-jbang scripts/ExportUtils.java '<report-content>' <format> [output-file]
-
-# TeamAggregator.java - Multi-user consolidation
-jbang scripts/TeamAggregator.java user1 user2 user3 <days> [repo]
-```
-
 ## Code Patterns & Conventions
 
 ### JBang Script Pattern
@@ -855,7 +830,6 @@ git push                # Push to remote
 - Always `bd sync` before ending session
 
 <!-- end-bv-agent-instructions -->
-
+    
 **Last Updated**: 2026-01-06
-**Maintained By**: claude-md-guardian agent (auto-sync on major changes)
-
+**Maintained By**: claude-md-guardian agent (auto-sync on major changes)/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -700,16 +700,40 @@ Example console debug output:
 
 This project uses [beads](https://github.com/steveyegge/beads) for AI-agent-friendly task tracking.
 
-**Quick Reference**:
+**See [AGENTS.md](AGENTS.md)** for detailed workflow patterns including:
+- When to use Beads vs OpenSpec decision table
+- Daily workflow (Orient → Pick → Implement → Complete)
+- Converting OpenSpec tasks to Beads with full context
+- Label conventions
+
+### STRICT RULE: Every `bd create` MUST include `-d`
+
+Issues must be **self-contained** - someone must understand the task with ONLY the description.
+
+**FORBIDDEN**:
+```bash
+bd create "Update file.ts" -t task
+```
+
+**REQUIRED**:
+```bash
+bd create "Add validation to user input" -t task -p 2 \
+  -d "## Requirements
+- Validate email format before submission
+- Show inline error message
+
+## Files to modify
+- src/components/UserForm.java"
+```
+
+### Quick Reference
+
 ```bash
 # View ready (unblocked) tasks
 bd ready
 
-# Create a new task
-bd create "Implement feature X"
-
-# Create with priority
-bd create "Critical bug fix" -p 0
+# Create a new task (ALWAYS include -d!)
+bd create "Task title" -t task -p 2 -d "## Requirements..."
 
 # Update task status
 bd update <id> --status in_progress
@@ -721,17 +745,18 @@ bd close <id> --reason "Implemented in PR #123"
 # Add dependency between tasks
 bd dep add <new-id> <blocking-id>
 
-# Export before committing (sync to git)
-bd export -o .beads/issues.jsonl
+# Sync before committing
+bd sync
 ```
 
-**Workflow**:
+### Workflow
+
 1. `bd ready` - Find unblocked tasks
 2. `bd update <id> --status in_progress` - Claim work
 3. Implement the task
 4. `bd close <id> --reason "message"` - Complete task
-5. `bd export -o .beads/issues.jsonl` - Export for git
-6. Commit `.beads/issues.jsonl` with your code changes
+5. `bd sync` - Sync beads database
+6. Commit and push your changes
 
 ---
 
@@ -798,6 +823,6 @@ git push                # Push to remote
 
 <!-- end-bv-agent-instructions -->
 
-**Last Updated**: 2026-01-05
+**Last Updated**: 2026-01-06
 **Maintained By**: claude-md-guardian agent (auto-sync on major changes)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,39 @@ This is a Claude Code slash command that generates AI-powered standup reports fr
 - Project files: `~/.claude-gh-standup/`
 - Command symlink: `~/.claude/commands/claude-gh-standup.md` → points to project's `.claude/commands/claude-gh-standup.md`
 
+## Working Style & Approach
+
+**CRITICAL: Think First, Code Once - Not the Other Way Around**
+
+When tackling any non-trivial task, especially those involving complex systems (API integrations, workflow orchestration, CLI parsing, etc.):
+
+### Required Process
+
+1. **ANALYZE FIRST** - Read and understand ALL relevant code before making any changes
+2. **MAP THE SYSTEM** - Identify all dependencies, interactions, and potential side effects
+3. **CLARIFY REQUIREMENTS** - If ANYTHING is unclear, ambiguous, or could be interpreted multiple ways, **STOP and ASK QUESTIONS**. Never assume or guess at requirements.
+4. **DESIGN COMPLETE SOLUTION** - Think through the entire approach on "paper" first
+5. **PRESENT THE PLAN** - Explain the strategy clearly before writing any code
+6. **IMPLEMENT CAREFULLY** - Make changes systematically, following the agreed plan
+7. **STICK TO THE PLAN** - Don't pivot to quick fixes that create new problems
+
+### Absolutely Forbidden
+
+- ❌ Making reactive changes without understanding root causes
+- ❌ Fixing one bug and creating another (going in circles)
+- ❌ Changing approach multiple times mid-task
+- ❌ Quick fixes that break other things
+- ❌ Jumping to implementation before thorough analysis
+
+### If You Get Stuck
+
+1. **STOP** - Don't keep trying random fixes
+2. **STEP BACK** - Re-analyze the entire system
+3. **ASK** - Request clarification or context from the user
+4. **REDESIGN** - Create a new plan based on better understanding
+
+**Remember:** Breaking more things than you fix wastes time and causes frustration. Spending 10 minutes on proper analysis upfront is better than 60 minutes going in circles.
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
## Summary

Follow-up to #37 with additional enhancements from the r/ClaudeCode OpenSpec+Beads discussion:

### CLAUDE.md
- Add "Working Style & Approach" section with Think First, Code Once philosophy
- Add 7-step Required Process (Analyze → Implement)
- Add Absolutely Forbidden anti-patterns list
- Add "If You Get Stuck" recovery process
- Remove duplicate "Testing Scripts Individually" section (24 lines)

### AGENTS.md
- Add `bd onboard` to session start instructions
- Add "Importing OpenSpec Tasks Checklist" with 4-point context requirements
- Expand Landing the Plane with detailed sub-steps and code examples
- Add `--add-note` command for session context
- Add Hand Off template for next session
- Add `bd sync` to CRITICAL RULES

Closes #36

## Test plan

- [x] CLAUDE.md Working Style section is clear and actionable
- [x] AGENTS.md Landing the Plane steps are detailed
- [x] No duplicate content remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)